### PR TITLE
[nrf noup] mgmt/mcumgr: Bootutil hooks to handle image-1

### DIFF
--- a/subsys/mgmt/mcumgr/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/CMakeLists.txt
@@ -15,3 +15,11 @@ add_subdirectory(grp)
 add_subdirectory(transport)
 
 zephyr_library_link_libraries(mgmt_mcumgr)
+
+if (CONFIG_BOOT_IMAGE_ACCESS_HOOKS)
+    zephyr_include_directories(
+        ${ZEPHYR_MCUBOOT_MODULE_DIR}/boot/bootutil/include
+        ${ZEPHYR_MCUBOOT_MODULE_DIR}/boot/zephyr/include
+    )
+    zephyr_library_sources(bootutil_hooks/nrf53_hooks.c)
+endif()

--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -7,6 +7,7 @@ menuconfig MCUMGR
 	select NET_BUF
 	select ZCBOR
 	select CRC
+	select BOOT_IMAGE_ACCESS_HOOKS if (SOC_NRF5340_CPUAPP_QKAA && MCUMGR_CMD_IMG_MGMT)
 	help
 	  This option enables the mcumgr management library.
 

--- a/subsys/mgmt/mcumgr/bootutil_hooks/nrf53_hooks.c
+++ b/subsys/mgmt/mcumgr/bootutil_hooks/nrf53_hooks.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include "bootutil/bootutil_public.h"
+
+int boot_read_swap_state_primary_slot_hook(int image_index,
+		struct boot_swap_state *state)
+{
+	if (image_index == 1) {
+		/* Pretend that primary slot of image 1 unpopulated */
+		state->magic = BOOT_MAGIC_UNSET;
+		state->swap_type = BOOT_SWAP_TYPE_NONE;
+		state->image_num = image_index;
+		state->copy_done = BOOT_FLAG_UNSET;
+		state->image_ok = BOOT_FLAG_UNSET;
+
+		/* Prevent bootutil from trying to obtain true info */
+		return 0;
+	}
+
+	return BOOT_HOOK_REGULAR;
+}


### PR DESCRIPTION
The commit adds bootutil hook, for nrf5340, to allow it handling the non-accessible image-1/primary slot.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>
Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>
(cherry picked from commit 0bff3b69a89c68d0c07d012603554b3c6b0b2acc)